### PR TITLE
Use of_device_id array

### DIFF
--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -19,4 +19,4 @@ jobs:
         chmod +x checkpatch.pl
 
     - name: Check the coding style
-      run: ./checkpatch.pl --no-tree -f module/*.[ch]
+      run: ./checkpatch.pl --no-tree -f --ignore UNDOCUMENTED_DT_STRING module/*.[ch]

--- a/module/mfrc522_module.c
+++ b/module/mfrc522_module.c
@@ -109,12 +109,18 @@ static struct miscdevice mfrc522_misc = {
 	.fops = &mfrc522_fops,
 };
 
+static const struct of_device_id mfrc522_match_table[] = {
+	{ .compatible = "mfrc522" },
+	{} // NULL entry
+};
+
 static int mfrc522_spi_probe(struct spi_device *spi);
 
 static struct spi_driver mfrc522_spi_driver = {
 	.driver = {
 		.name = "mfrc522",
 		.owner = THIS_MODULE,
+        .of_match_table = mfrc522_match_table,
 	},
 	.probe = mfrc522_spi_probe,
 };

--- a/module/mfrc522_module.c
+++ b/module/mfrc522_module.c
@@ -120,7 +120,7 @@ static struct spi_driver mfrc522_spi_driver = {
 	.driver = {
 		.name = "mfrc522",
 		.owner = THIS_MODULE,
-        .of_match_table = mfrc522_match_table,
+		.of_match_table = mfrc522_match_table,
 	},
 	.probe = mfrc522_spi_probe,
 };


### PR DESCRIPTION
Matching on the driver's name is considered deprecated in some cases and might cause
our driver to not compile anymore in the future. This PR proposes the use of an array
of `of_device_id` in order to ensure compatibility no matter the future behavior of
the `spi_driver` struct.

Closes #19